### PR TITLE
修改管理员判断方式

### DIFF
--- a/docs/namespaces/Func/functions/isAdmin.md
+++ b/docs/namespaces/Func/functions/isAdmin.md
@@ -9,8 +9,7 @@
 > **isAdmin**(`player`): `boolean`
 
 返回玩家是否管理员
-默认使用tag区分
-你可以自己改
+默认使用权限等级判断
 
 ## Parameters
 

--- a/src/Command/help.ts
+++ b/src/Command/help.ts
@@ -63,8 +63,8 @@ export class CommandHelp {
         player.sendMessage(text);
     }
     handleCommandHelp(player: Player, command: Command) {
-        const isop = isAdmin(player);
-        const usageList = getCommandUsage(command, isop);
+        const isOp = isAdmin(player);
+        const usageList = getCommandUsage(command, isOp);
         player.sendMessage(`§e.${command.name}:\n${command.explain}\n§f使用:\n`);
         for (const usage of usageList) {
             player.sendMessage("- ." + usage);
@@ -83,7 +83,7 @@ const EnterParam: enterNodeFunc<ParamDefinition> = (T, ctx, stack) => {
 
 const enterCommand: enterNodeFunc<Command> = (T, ctx, stack) => {
     const priorStr = stack.map((t) => t[0].name).join(" ");
-    if (((T.isAdmin && ctx.isop) || !T.isAdmin) && !T.isHidden) {
+    if (((T.isAdmin && ctx.isOp) || !T.isAdmin) && !T.isHidden) {
         //(所有参数为可选∩没有子命令)∪(所有参数为可选∩有处理函数)
         //即为:所有参数为可选∩(没有子命令∪有处理函数)
         if (
@@ -117,8 +117,8 @@ const enterCommand: enterNodeFunc<Command> = (T, ctx, stack) => {
         }
     }
 };
-function getCommandUsage(command: Command, isop: boolean) {
-    const ctx = { isop: isop, usageList: [], command: command };
+function getCommandUsage(command: Command, isOp: boolean) {
+    const ctx = { isOp: isOp, usageList: [], command: command };
     PreOrdertraverse(command, { getSubNodes: (T) => T.subCommands, enter: enterCommand, ctx: ctx });
     return ctx.usageList;
 }

--- a/src/Command/parser/parser.ts
+++ b/src/Command/parser/parser.ts
@@ -74,7 +74,7 @@ export class CommandParser {
                 paramStrings,
                 current,
                 showError,
-                "无权限执行此命令"
+                "权限不足，无法执行此命令"
             );
         }
         //执行命令验证器

--- a/src/func.ts
+++ b/src/func.ts
@@ -31,11 +31,10 @@ export function isNum(value: any): boolean {
 
 /**
  * 返回玩家是否管理员
- * 默认使用tag区分
- * 你可以自己改
+ * 默认使用权限等级判断
  * */
 export function isAdmin(player: Player) {
-    return player.hasTag("op");
+    return player.commandPermissionLevel >= 3;
 }
 
 export function getAllPlayers() {

--- a/src/func.ts
+++ b/src/func.ts
@@ -34,7 +34,7 @@ export function isNum(value: any): boolean {
  * 默认使用权限等级判断
  * */
 export function isAdmin(player: Player) {
-    return player.commandPermissionLevel >= 3;
+    return player.commandPermissionLevel >= 1;
 }
 
 export function getAllPlayers() {

--- a/tutorial/func.md
+++ b/tutorial/func.md
@@ -12,7 +12,7 @@ import { xxx } from "sapi-pro/scripts/func"; //或直接从func导入
 #### 玩家相关
 
 -   [isAdmin](../docs/namespaces/Func/functions/isAdmin.md)
-    **重要**:判断是否管理员，默认通过是否有 tag:op 来判断，你可以自己改逻辑
+    **重要**:判断是否管理员，默认通过自身权限等级是否≥3来判断
 -   [getAllPlayers](../docs/namespaces/Func/functions/getAllPlayers.md)
     获取所有玩家，(命令系统通过这个获取玩家)这个可以自定义，例如你想排除哪些玩家，可以自己改
 -   [getPlayerById](../docs/namespaces/Func/functions/getPlayerById.md) 根据实体 id 获取玩家

--- a/tutorial/func.md
+++ b/tutorial/func.md
@@ -12,7 +12,7 @@ import { xxx } from "sapi-pro/scripts/func"; //或直接从func导入
 #### 玩家相关
 
 -   [isAdmin](../docs/namespaces/Func/functions/isAdmin.md)
-    **重要**:判断是否管理员，默认通过自身权限等级是否≥3来判断
+    **重要**:判断是否管理员，默认通过自身权限等级是否≥1来判断
 -   [getAllPlayers](../docs/namespaces/Func/functions/getAllPlayers.md)
     获取所有玩家，(命令系统通过这个获取玩家)这个可以自定义，例如你想排除哪些玩家，可以自己改
 -   [getPlayerById](../docs/namespaces/Func/functions/getPlayerById.md) 根据实体 id 获取玩家


### PR DESCRIPTION
`2.1.0-beta`（后续为`2.1.0`）删除了不稳定的`player.isOp()`并加入了`player.commandPermissionLevel`等，截至目前兼容良好。

可以使用`player.commandPermissionLevel >= 3`判定某玩家为管理员，而不再需要`op`标签。

（不使用`player.playerPermissionLevel`：身份自定义的情况下无法确认是否有管理员权限）

https://github.com/XiaoYangx666/SAPI-Pro/pull/1/commits/04a989a2c23d11ed6acb9d986bbe9df5de08b722#diff-dd2372bb6b6b69b4c21699c1c2f5f17641666ae81b89e62d4c8c65b69b6302af